### PR TITLE
RDKBWIFI-24: Add vendor_elements buffer to wifi_front_haul_bss_t struct for shared use across VAP reconfigurations

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -2945,6 +2945,15 @@ typedef struct
 #define WIFI_AP_MAX_SSID_LEN 33
 
 /**
+ * @brief Maximum length of the vendor information elements buffer
+ *
+ * Not a standard value, but a reasonable maximum for vendor elements 
+ * Computed by taking Max MPDU size - ~ MAX 802.11 header size - 802.11 FCS size - ~Size of required IEs
+ * 2,310 is divisible by the typical Vendor IE size (7 = IE Type[1] + IE Length[1] + OUI[3] + VIE Type[1] + VIE Subtype [1])
+ */
+#define WIFI_AP_MAX_VENDOR_IE_LEN 2310
+
+/**
  * @brief Fronthaul BSS information.
  *
  * This structure contains information about a fronthaul BSS.
@@ -2988,6 +2997,8 @@ typedef struct {
   wifi_mld_info_ap_t mld_info;        /**< MLD information. */
   BOOL hostap_mgt_frame_ctrl;        /**< Whether hostapd management frame control is enabled. */
   BOOL mbo_enabled;                  /**< Whether MBO is enabled. */
+  UCHAR vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN]; /**< The vendor elements to be added to beacon/probe response frames. Includes IE ID (0xDD), Length, and Payload */
+  USHORT vendor_elements_len;        /**< Length of vendor_elements currently stored since it is not null terminated */
 } __attribute__((packed)) wifi_front_haul_bss_t;
 
 /**


### PR DESCRIPTION
RDKBWIFI-24: Add vendor_elements buffer to wifi_front_haul_bss_t struct for shared use across VAP reconfigurations

Reason for the change: Provides a place for the vendor IEs to be stored that is currently not available
Risks: Low
Priority: P0
