### PR TITLE
RDKB-58602: Halinterface change for passing colocated_mode

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -889,6 +889,7 @@ typedef struct
     CHAR software_version[DEFAULT_DEVICE_FIELD_LEN]; /**< Device software version. */
     mac_address_t cm_mac; /**< Cable modem MAC address. */
     mac_address_t al_1905_mac; /**< 802.11v AL MAC address. */
+    int colocated_mode; /**< Easymesh agent mode based on controller configuration */
 } __attribute__((packed)) wifi_platform_property_t;
 
 /**


### PR DESCRIPTION
Reason for change: rdk-wifi-hal reads colocated_mode from the json, which in turn is updated to OneWifi as part of wifi_prop structure.