### PR TITLE
RDKB-59179:6G Keep-Out Channel list for ACS

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -444,6 +444,7 @@ typedef struct
  * @brief Wi-Fi channel lists per bandwidth.
  */
 typedef struct {
+    wifi_channelBandwidth_t chanwidth; /**< Bandwidth to which the channel blocks are mapped to */
     INT num_channels_list; /**< The number of list of channels contained within a given bandwidth */
     wifi_channels_list_t channels_list[MAX_CHANNELS]; /**< List of channel lists */
 }__attribute__((packed)) wifi_channels_list_per_bandwidth_t;


### PR DESCRIPTION
Adding the missing wifi_channelBandwidth_t structure variable to take care of linux build failures