### PR TITLE
RDKB-59259: Remove duplicate op_class variable of wifi_radio_operation_t

### DIFF
--- a/include/wifi_hal_radio.h
+++ b/include/wifi_hal_radio.h
@@ -140,7 +140,6 @@ typedef struct
     BOOL enable;                /**< Whether the radio is enabled. */
     wifi_freq_bands_t band;    /**< The radio frequency band. */
     BOOL autoChannelEnabled;     /**< Whether auto channel selection is enabled. */
-    UINT op_class;              /**< The operating class. */
     UINT channel;               /**< The radio primary channel. */
     UINT numSecondaryChannels;  /**< The number of secondary channels in the list. */
     UINT channelSecondary[MAXNUMSECONDARYCHANNELS]; /**< The list of secondary radio channels. */


### PR DESCRIPTION
wifi_radio_operation_t structure has duplicate operating class variables op_class and operatingClass. Remove op_class variable, use of this variable is removed in OneWifi and rdk-wifi-hal repository.

Test Procedure: ssid change, radio info change tested with Easymesh agent and controller.