### PR TITLE
RDKB-57769: wifi tr181 to mlo configuration

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -2971,7 +2971,9 @@ typedef struct
 {
     BOOL mld_enable;      /**< Whether MLD snooping is enabled. */
     UINT mld_id;          /**< MLD group ID. */
+    UINT mld_link_id;     /**< Link ID */
     mac_address_t mld_addr; /**< MLD group MAC address. */
+    BOOL mld_apply;       /**< MLD configuration apply indication */
 } __attribute__((packed)) wifi_mld_common_info_t;
 
 /**


### PR DESCRIPTION
Reason for change: Implement the following tr181's to support configuration of mlo params, these need to be added under Device.WiFi.AccessPoint:
	mld_enable
	mld_id
	mld_link_id
	mld_addr
	mld_apply
corresponding to:
	RDK_VENDOR_ATTR_MLD_ENABLE
	RDK_VENDOR_ATTR_MLD_ID
	RKD_VENDOR_ATTR_MLD_LINK_ID
	RDK_VENDOR_ATTR_MLD_MAC
	RDK_VENDOR_ATTR_MLD_CONFIG_APPLY
Test Procedure: mld_enable - true for mlo, false for slo mld_id - should be from 0 to 7 from private through mesh mld_link_id - link id of vap
mld_addr - should be bssid of vap for slo, should be bssid of first vap of the group in an mlo. mld_apply - should be 1 for the last vap in a group Priority: P1
Risks: low