### PR TITLE
RDKB-60610: Implement channel change based on CSA beacon frame.

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -2016,6 +2016,7 @@ typedef enum
     WIFI_MGMT_FRAME_TYPE_DISASSOC = 8, /**< Disassociation frame. */
     WIFI_MGMT_FRAME_TYPE_ACTION = 9,   /**< Action frame. */
     WIFI_MGMT_FRAME_TYPE_AUTH_RSP = 10, /**< Authentication response frame. */
+    WIFI_MGMT_FRAME_TYPE_BEACON = 11,   /**< Beacon frame. */
 } wifi_mgmtFrameType_t;
 
 /**


### PR DESCRIPTION
Reason for change: Added new wifi mgmt frame type to include beacon frame.
Test Procedure: Ensure channel change work in easymesh network.
Risks: Medium
Priority: P1