### PR TITLE
RDKBWIFI-47: Adds frequency data to action frame callback

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -2051,6 +2051,7 @@ typedef struct
     INT sig_dbm;                /**< Signal strength in dBm. */
     INT phy_rate;               /**< Physical rate. */
     UCHAR token;                /**< Token. */
+    UINT recv_freq;             /**< Frequency at which the frame was received. */
     UINT len;                   /**< Length of the data. */
     UCHAR *data;                /**< Pointer to the data. */
 } __attribute__((packed)) wifi_frame_t;
@@ -2169,10 +2170,11 @@ typedef INT (* wifi_receivedDataFrame_callback)(INT apIndex, mac_address_t sta_m
  * @param[in] len      Length of the frame data.
  * @param[in] type     Type of the management frame.
  * @param[in] dir      Direction of the management frame.
+ * @param[in] recv_freq Frequency at which the frame was received.
  *
  * @returns The status of the operation.
  */
-typedef INT (* wifi_receivedMgmtFrame_callback)(INT apIndex, UCHAR *sta_mac, UCHAR *frame, UINT len, wifi_mgmtFrameType_t type, wifi_direction_t dir);
+typedef INT (* wifi_receivedMgmtFrame_callback)(INT apIndex, UCHAR *sta_mac, UCHAR *frame, UINT len, wifi_mgmtFrameType_t type, wifi_direction_t dir, unsigned int recv_freq);
 
 
 /**


### PR DESCRIPTION
Reason for change: Certain applications need to know what frequency an action frame was recieved on.
Risks: High
Priority: P1

Impacts rdk-wifi-hal and OneWifi which is addressed in rdk-wifi-hal PR [#344](https://github.com/rdkcentral/rdk-wifi-hal/pull/344) and OneWifi PR [#576](https://github.com/rdkcentral/OneWifi/pull/576)

Will need to be throughly tested with Comcast devices before merging