### PR TITLE
RDKCOM-5580: RDKBDEV-3433 RDKBWIFI-202 Implementation of Traffic Separation

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -3227,6 +3227,7 @@ typedef struct
     CHAR bridge_name[WIFI_BRIDGE_NAME_LEN]; /**< Bridge name. */
     wifi_vap_mode_t vap_mode;      /**< VAP mode. */
     wifi_vap_name_t repurposed_vap_name; /**< Repurposed VAP name. */
+    int vlan_id; /**< VLAN ID for the VAP. */
     CHAR repurposed_bridge_name[WIFI_BRIDGE_NAME_LEN]; /**< Repurposed Bridge Name. */
     union
     {


### PR DESCRIPTION
Reason for change: Added traffic seperation TLV implementation via single bridge
Test Procedure: Verify build is successfull and check if traffic seperation is functional
Risks: Medium
Priority: P2