### PR TITLE
RDKBWIFI-386: Channel Scan Report - BSS Load element is wrong

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -373,9 +373,11 @@ typedef struct
     wifi_bitrate_t basic_rates; /**< Basic rates. */
     wifi_bitrate_t supp_rates; /**< Supported rates. */
     unsigned int dtim_period; /**< DTIM period. */
-    unsigned int chan_utilization; /**< Channel utilization. */
+    unsigned int chan_utilization; /**< Channel utilization.  As per R6 spec, this is valid only if BSS load element is present */
     int noise; /**< Noise. */
     int snr;  /**< SNR.  */
+    BOOL bss_load_element_present; /**< BSS Load element. */
+    unsigned int station_cnt; /**< Station count. As per R6 spec, this is valid only if BSS load element is present */
 } __attribute__((packed)) wifi_bss_info_t;
 
 /**

--- a/include/wifi_hal_telemetry.h
+++ b/include/wifi_hal_telemetry.h
@@ -106,8 +106,10 @@ typedef struct _wifi_neighbor_ap2
     CHAR ap_BasicDataTransferRates[256]; /**< Comma-separated list (maximum list length 256) of strings. Basic data transmit rates (in Mbps) for the SSID. For example, if ap_BasicDataTransferRates is "1,2", this indicates that the SSID is operating with basic rates of 1 Mbps and 2 Mbps. */
     CHAR ap_SupportedDataTransferRates[256]; /**< Comma-separated list (maximum list length 256) of strings. Data transmit rates (in Mbps) for unicast frames at which the SSID will permit a station to connect. For example, if ap_SupportedDataTransferRates is "1,2,5.5", this indicates that the SSID will only permit connections at 1 Mbps, 2 Mbps and 5.5 Mbps. */
     UINT ap_DTIMPeriod;               /**< The number of beacon intervals that elapse between transmission of Beacon frames containing a TIM element whose DTIM count field is 0. This value is transmitted in the DTIM Period field of beacon frames. [802.11-2012] */
-    UINT ap_ChannelUtilization;       /**< Indicates the fraction of the time the AP senses that the channel is in use by the neighboring AP for transmissions. */
+    UINT ap_ChannelUtilization;       /**< Indicates the fraction of the time the AP senses that the channel is in use by the neighboring AP for transmissions. Valid only when bss_load_element_present is true. */
     UINT ap_freq;                        /**< Frequency. */
+    BOOL bss_load_element_present;    /**< Flag indicating presence of BSS Load IE; controls validity of related fields. */
+    UINT ap_StaCount;                /**< Number of stations currently associated with the BSS. Valid only when bss_load_element_present is true. */
 } wifi_neighbor_ap2_t;
 
 /*    Explanation:


### PR DESCRIPTION
    Add support for BSS Load element information in WiFi HAL by
    introducing a presence flag and associated fields.

    Changes:
    - Add bss_load_element_present to indicate presence of BSS Load IE
    - Add station count field (station_cnt / ap_StaCount)
    - Channel utilization is considered valid only when the IE is present
    - Include <stdbool.h> for bool type support

    These fields enable correct propagation of BSS Load information
    from scan results to higher layers.