### PR TITLE
RDKB-61540: MLO support: add MLD interface to interface map (#47)

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -856,6 +856,7 @@ typedef struct
     unsigned int phy_index; /**< Actual index of the PHY device. */
     unsigned int rdk_radio_index; /**< Radio index of the upper layer. */
     wifi_interface_name_t interface_name; /**< Interface name. */
+    wifi_interface_name_t mld_interface_name; /**< MLD interface name. */
     wifi_interface_name_t bridge_name; /**< Bridge name. */
     int vlan_id; /**< VLAN ID. */
     unsigned int index; /**< Index. */


### PR DESCRIPTION
Reason for change: add MLD interface to interface map Test Procedure:
Risks: Low
Priority: P1