### PR TITLE
RDKB-63482: MLO: exclude VAPs from group on SSID/security mismatch

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -3115,6 +3115,8 @@ typedef struct
     UINT mld_link_id;     /**< Link ID */
     mac_address_t mld_addr; /**< MLD group MAC address. */
     BOOL mld_apply;       /**< MLD configuration apply indication */
+    BOOL mld_link_excluded;    /**< true when VAP excluded from MLO group due to
+                                    SSID/password/security mode mismatch with main link */
 } __attribute__((packed)) wifi_mld_common_info_t;
 
 /**


### PR DESCRIPTION
Reason for change: A VAP with a mismatched SSID or security config
                   is incorrectly included in the MLO group. Add
                   mld_link_excluded to wifi_mld_common_info_t to
                   allow the manager to signal per-link exclusion
                   to the platform layer.
Test Procedure: 1. Configure MLO.
				2. Change non main link VAP's SSID and/or security config to mismatch the main link.
				3. Observe that the VAP is excluded from the MLO group.
				4. Restore the VAP's SSID/security config to match the main link.
				5. Observe that the VAP is included in the MLO group.
				6. Change main link's SSID/security config to mismatch the non-main link.
				7. Observe that the mlo group is destroyed. Check if client can connect to the VAP in all cases.

Priority: P1
Risks: Medium