### PR TITLE
RDKB-63482: Remove outdated mld_apply from wifi_mld_common_info_t

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -3114,7 +3114,6 @@ typedef struct
     UINT mld_id;          /**< MLD group ID. */
     UINT mld_link_id;     /**< Link ID */
     mac_address_t mld_addr; /**< MLD group MAC address. */
-    BOOL mld_apply;       /**< MLD configuration apply indication */
 } __attribute__((packed)) wifi_mld_common_info_t;
 
 /**


### PR DESCRIPTION
Reason for change: Cleanup
Test Procedure: 1. Configure MLO.
			Verify that MLO group is configured properly

Priority: P1
Risks: Medium