### PR TITLE
XB10-2684 Populate link address for MLO client's assoc events (#106)

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -1535,6 +1535,7 @@ typedef struct {
     UCHAR cli_LinkID;
     UINT cli_VapIndex;
     INT cli_RSSI;
+    UCHAR cli_LinkAddress[6];
 } wifi_mld_sta_link_info_t;
 
 typedef struct {


### PR DESCRIPTION
Reason for change: LinkAddress is empty for MLO client's assoc events
Test Procedure: Connect MLO client to AP and verify the link address is correctly populated in the stats and events.
Risks: Low
Priority: P1


(cherry picked from commit 44165a08fb414d53b8918dffea46ecc3ec0b2553)