### PR TITLE
RDKBWIFI-477 halif: Add ACS channel exclusion list API and types

### DIFF
--- a/include/wifi_hal_radio.h
+++ b/include/wifi_hal_radio.h
@@ -215,6 +215,21 @@ typedef enum
     wifi_dl_data_block_ack_deferred, /**< Deferred block acknowledgement. */
 } wifi_dl_data_ack_type_t;
 
+/**
+ * @brief ACS channel exclusion entry.
+ *
+ * Represents a single {operating class, channel} pair to be excluded
+ * from Automatic Channel Selection (ACS). An array of these entries
+ * forms the ACS exclusion list passed to the HAL via
+ * wifi_hal_set_acs_exclusion_list().
+ *
+ * Operating class values follow IEEE Std 802.11-2020, Annex E.
+ */
+typedef struct {
+    INT op_class;   /**< Global operating class (IEEE 802.11 Annex E). */
+    INT channel;    /**< Channel number to exclude within the operating class. */
+} wifi_hal_acs_exclude_t;
+
 /** @} */  //END OF GROUP WIFI_HAL_TYPES
 
 /**
@@ -975,6 +990,37 @@ void wifi_scanResults_callback_register(wifi_scanResults_callback callback_proc)
  */
 INT wifi_hal_getRadioTemperature(wifi_radio_index_t radioIndex, wifi_radioTemperature_t *output_struct);
 
+/**
+ * @brief Sets the ACS channel exclusion list for a radio.
+ *
+ * This function passes an array of {operating class, channel} pairs to the
+ * HAL to be excluded from Automatic Channel Selection (ACS). The HAL converts
+ * the entries into the hostapd-internal format and stores them under mutex
+ * protection for use by the ACS engine.
+ *
+ * Additionally, the function checks whether the radio's current operating
+ * channel and bandwidth match any entry in the exclusion list, and reports
+ * the result via @p operating_channel_excluded.
+ *
+ * Pass list=NULL or count=0 to clear the exclusion list.
+ *
+ * Operating class values follow IEEE Std 802.11-2020, Annex E.
+ *
+ * @param[in]  radioIndex                 Index of the Wi-Fi radio.
+ * @param[in]  list                       Array of wifi_hal_acs_exclude_t
+ *                                        entries. NULL to clear.
+ * @param[in]  count                      Number of entries in @p list.
+ *                                        0 to clear.
+ * @param[out] operating_channel_excluded Pointer to a variable set to 1 if the
+ *                                        current operating channel and bandwidth
+ *                                        match any entry in the exclusion list,
+ *                                        0 otherwise. Must not be NULL.
+ *
+  * @returns The status of the operation.
+ * @retval WIFI_HAL_SUCCESS If successful.
+ * @retval WIFI_HAL_ERROR   If any error is detected.
+ */
+INT wifi_hal_set_acs_exclusion_list(wifi_radio_index_t radioIndex, wifi_hal_acs_exclude_t *list, INT count, INT *operating_channel_excluded);
 
 /** @} */  //END OF GROUP WIFI_HAL_APIS
 


### PR DESCRIPTION
Introduce wifi_hal_acs_exclude_t structure and
wifi_hal_set_acs_exclusion_list() API declaration in wifi_hal_radio.h to support ACS channel exclusion list functionality.

The API allows passing a list of {operating class, channel} pairs to be excluded from ACS and reports whether the current operating channel is part of the exclusion list.

Signed-off-by: sgunasekaran@maxlinear.com