### PR TITLE
BCOMB-3480: Client connectivity drop due to Gateway blocking Unencrypted frames

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -1900,6 +1900,7 @@ typedef INT ( * wifi_device_deauthenticated_callback)(int ap_index, char *src_ma
  * @param callback_proc Pointer to the callback function to register.
  */
 void wifi_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback callback_proc);
+/** @} */  //END OF GROUP WIFI_HAL_APIS
 
 /**
  * @addtogroup WIFI_HAL_TYPES

--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -1902,6 +1902,48 @@ typedef INT ( * wifi_device_deauthenticated_callback)(int ap_index, char *src_ma
 void wifi_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback callback_proc);
 
 /**
+ * @addtogroup WIFI_HAL_TYPES
+ * @{
+ */
+/* wifi_apFrameDropUnencrypted_callback() function */
+/**
+* @brief Callback invoked when the AP drops an unencrypted data frame received
+* from an associated STA on a security-enforced BSS (FC_WEP bit not set after
+* EAPOL has completed).  The STA has likely lost its PTK/GTK and the consumer
+* is expected to disassociate it so a fresh 4-way handshake takes place.
+*
+* @param[in] ap_index   Access Point Index
+* @param[in] src_mac    MAC address of the STA that sent the unprotected frame
+* @param[in] ether_type Ethertype of the dropped frame in host byte order
+*
+* @return The status of the operation
+* @retval RETURN_OK if successful
+* @retval RETURN_ERR if any error is detected
+*
+* @note This function must not suspend and must not invoke any blocking system
+* calls.  It should send a message to a driver event handler task which is
+* responsible for performing the actual disassociation.
+*/
+typedef INT ( * wifi_apFrameDropUnencrypted_callback)(int ap_index, char *src_mac, unsigned short ether_type);
+
+/** @} */  //END OF GROUP WIFI_HAL_TYPES
+
+/**
+ * @addtogroup WIFI_HAL_APIS
+ * @{
+ */
+/**
+ * @brief Registers a callback function for unprotected-frame drop events.
+ *
+ * The callback is invoked when the driver reports that an unencrypted data
+ * frame was dropped on a secured AP BSS for an associated STA.  The consumer
+ * is expected to react by disassociating the offending STA.
+ *
+ * @param callback_proc Pointer to the callback function to register.
+ */
+void wifi_apFrameDropUnencrypted_callback_register(wifi_apFrameDropUnencrypted_callback callback_proc);
+
+/**
  * @brief Sets the interworking access network type for an Access Point.
  *
  * This function sets the access network type that will be included in the

--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -1916,9 +1916,9 @@ void wifi_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback callback_p
 * @param[in] src_mac    MAC address of the STA that sent the unprotected frame
 * @param[in] ether_type Ethertype of the dropped frame in host byte order
 *
-* @return The status of the operation
-* @retval RETURN_OK if successful
-* @retval RETURN_ERR if any error is detected
+* @returns The status of the operation
+* @retval WIFI_HAL_SUCCESS If successful
+* @retval WIFI_HAL_ERROR   If any error is detected
 *
 * @note This function must not suspend and must not invoke any blocking system
 * calls.  It should send a message to a driver event handler task which is


### PR DESCRIPTION
Reason for change : DHCP discover gets dropped because STA sends it without encryption.
Proposed Fix : Disassociate the client if it doesn't have IP
Test Proceedure : STA sending unprotected frame without having IP should disassociate.
Priority: P0
Risks: Low