### PR TITLE
XB10-2872: Add per  radio-level MLD link ID

### DIFF
--- a/include/wifi_hal_radio.h
+++ b/include/wifi_hal_radio.h
@@ -192,6 +192,7 @@ typedef struct
     wifi_channels_list_per_bandwidth_t  channels_per_bandwidth[MAX_NUM_CHANNELBANDWIDTH_SUPPORTED]; /**< All the channel list for a particular channel bandwidth */
     UINT numOperatingClasses; /**< Number of valid operating classes in the array operatingClasses */
     wifi_operating_classes_t operatingClasses[MAXNUMOPERCLASSESPERBAND]; /**< Array of supported Operating classes as per Data elements Schema */
+    UINT mldLinkId; /**< MLD Link ID for this radio (802.11be MLO). 255 indicates unset. */
 } __attribute__((packed)) wifi_radio_operationParam_t;
 
 /**


### PR DESCRIPTION
Reason for change: Move MLD link ID ownership to radio configuration
Test Procedure: Configure MLO and check client connectivity
Risks: Low
Priority: P1