### PR TITLE
 BCOMB-3550 BCOMB-3437: Detect PowerSave mode and acumulate sleep time.

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -1264,6 +1264,7 @@ typedef struct _wifi_associated_dev3
     wifi_multi_link_modes_t cli_MLModeCapa; /* Bitmap of the the MLD operation modes supported by the client */
     BOOL cli_TIDLinkMapNegotiation; /* Indicates whether TID to Link MAP negotiation is supported by client */
     mac_address_t cli_MLDAddr; /* Indicates the MLD MAC address of the connected client, 00's for non-Wi-Fi 7 clients. */
+    BOOL cli_PowerSaveMode;  /* Indicates the station is in Power save mode or not. */
 } wifi_associated_dev3_t;
 
 /** @} */  //END OF GROUP WIFI_HAL_TYPES


### PR DESCRIPTION
[BCOMB-3550](https://ccp.sys.comcast.net/browse/BCOMB-3550) [BCOMB-3437](https://ccp.sys.comcast.net/browse/BCOMB-3437): Detect PowerSave mode and acumulate sleep time.

Reason for change: Expose client on RDK_VENDOR_NL80211_SUBCMD_GET_STATION
 via nested RDK_VENDOR_ATTR_STA_INFO_POWER_SAVE and RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS
Test Procedure: Update upper layer to parse POWER_SAVE and SLEEP_TIME_MS; Check the output.
Risks: Low
Priority: P1
Signed-off-by: Pramod joshi <pramod.7456@gmail.com>