### PR TITLE
RDKB-66288 --Change Sleep time to UINT64

### DIFF
--- a/include/wifi_hal_generic.h
+++ b/include/wifi_hal_generic.h
@@ -1284,7 +1284,7 @@ typedef struct _wifi_associated_dev3
     BOOL cli_TIDLinkMapNegotiation; /* Indicates whether TID to Link MAP negotiation is supported by client */
     mac_address_t cli_MLDAddr; /* Indicates the MLD MAC address of the connected client, 00's for non-Wi-Fi 7 clients. */
     BOOL cli_PowerSaveMode;  /* Indicates the station is in Power save mode or not. */
-    UINT cli_sleepTime;  /* Indicates the station's sleep time. */
+    ULONG cli_sleepTime;  /* Indicates the station's sleep time. */
 } wifi_associated_dev3_t;
 
 /** @} */  //END OF GROUP WIFI_HAL_TYPES


### PR DESCRIPTION
Reason for change: Change Sleep time to UINT64

Test Procedure: Update upper layer to parse POWER_SAVE and SLEEP_TIME_MS; Check the output. 
Risks: Low
Priority: P1
Signed-off-by: Pramod joshi pramod.7456@gmail.com